### PR TITLE
add CI and make tests pass

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,63 @@
+name: CI
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.6"
+          - "1"
+          - "nightly"
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.arch }}-test-
+            ${{ runner.os }}-${{ matrix.arch }}-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+          parallel: true
+          path-to-lcov: lcov.info
+
+  finish:
+    name: Coveralls Finished
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+￼on:
+￼  issue_comment:
+￼    types:
+￼      - created
+￼  workflow_dispatch:
+￼jobs:
+￼  TagBot:
+￼    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+￼    runs-on: ubuntu-latest
+￼    steps:
+￼      - uses: JuliaRegistries/TagBot@v1
+￼        with:
+￼          token: ${{ secrets.GITHUB_TOKEN }}
+￼          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/src/ServerMetrics.jl
+++ b/src/ServerMetrics.jl
@@ -15,7 +15,6 @@ export AbstractMetricCollection, register_collection!, publish_metrics_from
 export Counter, Gauge, inc!, dec!, set!
 export StatsdExporter, start_statsd_exporter!, stop_statsd_exporter!
 export handle_metrics
-export hydra_metrics, hydra_metric
 
 include("server-metrics.jl")
 include("dogstatsd-exporter.jl")

--- a/src/prometheus-exporter.jl
+++ b/src/prometheus-exporter.jl
@@ -54,7 +54,7 @@ format.
 This can be registered to `/metrics` HTTP endpoint to enable integration with prometheus
 monitoring system.
 """
-function handle_metrics()
+function handle_metrics(request)
     buffer = Base.IOBuffer()
     registry = get_default_registry()
     for (name, metric) in registry.metrics

--- a/test/prometheus-exporter.jl
+++ b/test/prometheus-exporter.jl
@@ -6,7 +6,7 @@ using HTTP
     c = register!(Counter(), "my_counter")
     inc!(c, 2.0)
 
-    resp = handle_metrics(HTTP.Request("GET", "/metrics"), nothing)
+    resp = handle_metrics(nothing)
     @test String(resp.body) == """
     # TYPE my_counter counter
     my_counter 2.0
@@ -14,7 +14,7 @@ using HTTP
     """
 
     inc!(c, 3.0)
-    resp = handle_metrics(HTTP.Request("GET", "/metrics"), nothing)
+    resp = handle_metrics(nothing)
     @test String(resp.body) == """
     # TYPE my_counter counter
     my_counter 5.0
@@ -25,7 +25,7 @@ end
 @testcase "Simple gauge" begin
     clear_registry!(get_default_registry())
     g = register!(Gauge(1.5), "my_gauge")
-    resp = handle_metrics(HTTP.Request("GET", "/metrics"), nothing)
+    resp = handle_metrics(nothing)
 
     @test String(resp.body) == """
     # TYPE my_gauge gauge
@@ -39,7 +39,7 @@ end
     c = register!(Counter(;action=String,response_code=Int64), "requests")
     inc!(c; action="get", response_code=404)
     inc!(c; action="put", response_code=500)  # What a bad day for prod :-(
-    resp = handle_metrics(HTTP.Request("GET", "/metrics"), nothing)
+    resp = handle_metrics(nothing)
 
     @test String(resp.body) == """
     # TYPE requests counter
@@ -55,7 +55,7 @@ end
     set!(temp, 36.0; location="outside", hour=6)
     set!(temp, 40.0; location="outside", hour=8)
     set!(temp, 60.0; location="inside", hour=8)
-    resp = handle_metrics(HTTP.Request("GET", "/metrics"), nothing)
+    resp = handle_metrics(nothing)
 
     @test String(resp.body) == """
     # TYPE temperature gauge
@@ -71,7 +71,7 @@ end
     bbb = register!(Counter(), "bbb")
     zzz = register!(Gauge(0.2), "zzz")
     aaa = register!(Counter(), "aaa")
-    resp = handle_metrics(HTTP.Request("GET", "/metrics"), nothing)
+    resp = handle_metrics(nothing)
 
     @test String(resp.body) == """
     # TYPE aaa counter

--- a/test/statsd-exporter.jl
+++ b/test/statsd-exporter.jl
@@ -154,6 +154,7 @@ end
 end
 
 @testcase "StatsdExporter not exporting with send_interval=0" begin
+    clear_registry!(get_default_registry())
     mock_statsd = MockStatsdBackend()
     exporter = StatsdExporter(
         send_interval=Millisecond(0),


### PR DESCRIPTION
Shamelessly copied over from @vilterp's [PR](https://github.com/RelationalAI-oss/ServerMetrics.jl/pull/7) , which was in turn shamelessly copied from @NHDaly's PerformanceProfilingHttpEndpoints.jl

Strangely, CompatHelper was already there, but doesn't appear to be running… Maybe GH actions aren't turned on?

also fixes some tests that never worked 🙈 <shamecube>

Co-authored-by:@vilterp